### PR TITLE
fix: callback handlers for queue workers

### DIFF
--- a/src/SubscribableServiceProvider.php
+++ b/src/SubscribableServiceProvider.php
@@ -33,15 +33,9 @@ class SubscribableServiceProvider extends ServiceProvider
     public function register()
     {
         $this->app->bind(MailChannel::class, SubscriberMailChannel::class);
-        if (method_exists($this->app, 'scoped')) {
-            $this->app->scoped(Subscriber::class, function (Application $app) {
-                return new Subscriber($app);
-            });
-        } else {
-            $this->app->singleton(Subscriber::class, function (Application $app) {
-                /** @phpstan-ignore-next-line */
-                return new Subscriber($app);
-            });
-        }
+        $this->app->singleton(Subscriber::class, function (Application $app) {
+            /** @phpstan-ignore-next-line */
+            return new Subscriber($app);
+        });
     }
 }


### PR DESCRIPTION
When using a queue worker, each notification resets the scope. The problem here is that when this happens, all of the callbacks that were registered are no longer available - this is because they were all registered to a scoped singleton. I'm not sure how anyone else is able to use this package with a queue worker - out of the box it only works on "sync" mode, unless we remove the scoped singleton.

In-fact, I'm curious as to why the singleton was scoped in the first place as part of the laravel 9 compatibility upgrades?