### PR TITLE
PHP 8.4 testing

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.3'
           coverage: none
 
       - name: Install composer dependencies

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        php: [8.3, 8.2]
+        php: [8.4, 8.3, 8.2]
         laravel: ['11.*', '10.*']
         stability: [prefer-lowest, prefer-stable]
         include:

--- a/tests/MailSubscriberTest.php
+++ b/tests/MailSubscriberTest.php
@@ -3,6 +3,7 @@
 namespace YlsIdeas\SubscribableNotifications\Tests;
 
 use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\URL;
 use Orchestra\Testbench\TestCase;
 use YlsIdeas\SubscribableNotifications\Facades\Subscriber;
 use YlsIdeas\SubscribableNotifications\SubscribableServiceProvider;
@@ -45,8 +46,9 @@ class MailSubscriberTest extends TestCase
 
         $url = $user->unsubscribeLink();
 
+
         $this->assertEquals(
-            'http://localhost/unsubscribe/1?signature=bcc7b9f9909fb5f427f1b55022ee44eafee3d655a449f48d2e751748e1a9bcdf',
+            URL::signedRoute('unsubscribe', ['subscriber' => 1]),
             $url
         );
     }
@@ -68,7 +70,7 @@ class MailSubscriberTest extends TestCase
         $url = $user->unsubscribeLink('test');
 
         $this->assertEquals(
-            'http://localhost/unsubscribe/1/test?signature=edaf5bee199875521054535be04273c5006e4d6d834c98a83a3aa16a92223814',
+            URL::signedRoute('unsubscribe', ['subscriber' => 1, 'mailingList' => 'test']),
             $url
         );
     }


### PR DESCRIPTION
# Changes

- Fixes a test breaking in Laravel's latest release
- Bumps the testing to include PHP 8.4

# Why

Maintenance.