### PR TITLE
Mark deprecated features for v2.0 removal with deprecation warnings

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -5,3 +5,8 @@ parameters:
 			identifier: trait.unused
 			count: 1
 			path: src/MailSubscriber.php
+		-
+			message: '#^Access to constant on deprecated class YlsIdeas\\SubscribableNotifications\\Channels\\SubscriberMailChannel#'
+			identifier: classConstant.deprecatedClass
+			count: 1
+			path: src/SubscribableServiceProvider.php

--- a/src/Channels/SubscriberMailChannel.php
+++ b/src/Channels/SubscriberMailChannel.php
@@ -11,6 +11,12 @@ use YlsIdeas\SubscribableNotifications\Contracts\CanUnsubscribe;
 use YlsIdeas\SubscribableNotifications\Contracts\CheckNotifiableSubscriptionStatus;
 use YlsIdeas\SubscribableNotifications\Contracts\CheckSubscriptionStatusBeforeSendingNotifications;
 
+/**
+ * @deprecated v1.x will be removed in v2.0. Automatic unsubscribe-link injection via a custom
+ *             MailChannel is replaced by explicit opt-in: return SubscribableMailMessage::via($notifiable, $this)
+ *             from your notification's toMail() method instead.
+ *             See the upgrade guide: UPGRADE.md
+ */
 class SubscriberMailChannel extends MailChannel
 {
     /**
@@ -29,6 +35,13 @@ class SubscriberMailChannel extends MailChannel
      */
     public function send($notifiable, Notification $notification)
     {
+        trigger_error(
+            'SubscriberMailChannel is deprecated and will be removed in v2.0.'
+                . ' Return SubscribableMailMessage::via($notifiable, $this) from your notification\'s'
+                . ' toMail() method to opt in to unsubscribe-link injection explicitly.',
+            E_USER_DEPRECATED
+        );
+
         // Check if the user would want the mail
         if ($notifiable instanceof CheckSubscriptionStatusBeforeSendingNotifications &&
             $notification instanceof CheckNotifiableSubscriptionStatus &&

--- a/src/Contracts/CheckNotifiableSubscriptionStatus.php
+++ b/src/Contracts/CheckNotifiableSubscriptionStatus.php
@@ -2,6 +2,12 @@
 
 namespace YlsIdeas\SubscribableNotifications\Contracts;
 
+/**
+ * @deprecated v1.x will be removed in v2.0. Subscription gating is now handled by
+ *             SubscribableMailMessage::via() rather than the SubscriberMailChannel.
+ *             Remove this interface from your notifications.
+ *             See the upgrade guide: UPGRADE.md
+ */
 interface CheckNotifiableSubscriptionStatus
 {
     public function checkMailSubscriptionStatus(): bool;

--- a/src/Contracts/CheckSubscriptionStatusBeforeSendingNotifications.php
+++ b/src/Contracts/CheckSubscriptionStatusBeforeSendingNotifications.php
@@ -4,6 +4,12 @@ namespace YlsIdeas\SubscribableNotifications\Contracts;
 
 use Illuminate\Notifications\Notification;
 
+/**
+ * @deprecated v1.x will be removed in v2.0. Subscription gating is now handled by
+ *             SubscribableMailMessage::via() rather than the SubscriberMailChannel.
+ *             Remove this interface from your models.
+ *             See the upgrade guide: UPGRADE.md
+ */
 interface CheckSubscriptionStatusBeforeSendingNotifications
 {
     public function mailSubscriptionStatus(Notification $notification): bool;

--- a/src/Facades/Subscriber.php
+++ b/src/Facades/Subscriber.php
@@ -12,7 +12,7 @@ use Illuminate\Support\Facades\Facade;
  *
  * @method static void routes()
  * @method static string routeName()
- * @method static mixed userModel(string $model = null)
+ * @method static mixed userModel(string $model = null) @deprecated v1.x will be removed in v2.0. Remove all userModel() calls; model resolution is now polymorphic via the URL.
  * @method static void onCompletion(callable|string $handler)
  * @method static void onUnsubscribeFromMailingList(callable|string $handler)
  * @method static void onUnsubscribeFromAllMailingLists(callable|string $handler)

--- a/src/SubscribableApplicationServiceProvider.php
+++ b/src/SubscribableApplicationServiceProvider.php
@@ -4,6 +4,11 @@ namespace YlsIdeas\SubscribableNotifications;
 
 use Illuminate\Support\ServiceProvider;
 
+/**
+ * @deprecated v1.x will be removed in v2.0. Publish the subscriber-provider stub and configure
+ *             Subscriber callbacks directly in your own service provider's boot() method instead.
+ *             See the upgrade guide: UPGRADE.md
+ */
 abstract class SubscribableApplicationServiceProvider extends ServiceProvider
 {
     /**
@@ -18,6 +23,15 @@ abstract class SubscribableApplicationServiceProvider extends ServiceProvider
 
     public function boot()
     {
+        trigger_error(
+            sprintf(
+                '%s is deprecated and will be removed in v2.0. Publish the subscriber-provider stub'
+                    . ' and configure Subscriber callbacks directly in your boot() method instead.',
+                static::class
+            ),
+            E_USER_DEPRECATED
+        );
+
         if ($this->loadRoutes === true) {
             $this->loadRoutes();
         }

--- a/src/Subscriber.php
+++ b/src/Subscriber.php
@@ -74,11 +74,22 @@ class Subscriber
     }
 
     /**
+     * @deprecated v1.x will be removed in v2.0. Model resolution is now polymorphic via the URL.
+     *             Remove all Subscriber::userModel() calls and add a morph map instead.
+     *             See the upgrade guide: UPGRADE.md
+     *
      * @param string|null $model
      * @return string|null
      */
     public function userModel(?string $model = null)
     {
+        trigger_error(
+            'Subscriber::userModel() is deprecated and will be removed in v2.0.'
+                . ' Model resolution is now polymorphic via the URL.'
+                . ' Remove all userModel() calls and register a morph map instead.',
+            E_USER_DEPRECATED
+        );
+
         if ($model) {
             $this->userModel = $model;
 

--- a/stubs/SubscribableServiceProvider.stub
+++ b/stubs/SubscribableServiceProvider.stub
@@ -1,5 +1,9 @@
 <?php
 
+// @deprecated This stub and SubscribableApplicationServiceProvider will be removed in v2.0.
+// After upgrading to v2, run `php artisan vendor:publish --tag=subscriber-provider` to get
+// the new plain-stub and migrate your callbacks. See UPGRADE.md for details.
+
 namespace App\Providers;
 
 use YlsIdeas\SubscribableNotifications\SubscribableApplicationServiceProvider;


### PR DESCRIPTION
## Summary
This PR adds deprecation notices to several features that will be removed in v2.0, guiding users toward the recommended upgrade path. Each deprecated component now includes both PHPDoc annotations and runtime deprecation warnings via `trigger_error()`.

## Key Changes
- **SubscribableApplicationServiceProvider**: Added deprecation notice directing users to publish the subscriber-provider stub and configure callbacks directly in their service provider's `boot()` method
- **SubscriberMailChannel**: Added deprecation notice recommending explicit opt-in via `SubscribableMailMessage::via()` instead of automatic unsubscribe-link injection
- **Subscriber::userModel()**: Added deprecation notice directing users to remove calls and use polymorphic model resolution via morph maps instead
- **CheckNotifiableSubscriptionStatus interface**: Added deprecation notice indicating subscription gating is now handled by `SubscribableMailMessage::via()`
- **CheckSubscriptionStatusBeforeSendingNotifications interface**: Added deprecation notice indicating subscription gating is now handled by `SubscribableMailMessage::via()`

## Implementation Details
- All deprecation warnings use `E_USER_DEPRECATED` to allow users to control handling via error reporting configuration
- Each deprecated component includes a reference to `UPGRADE.md` for detailed migration guidance
- Runtime warnings are triggered at the point of use (method calls or class instantiation) to ensure users are notified during development
- PHPDoc annotations provide IDE support and static analysis hints about deprecation status

https://claude.ai/code/session_01MsY3G5SB16WXTcZGkMb7FX